### PR TITLE
Desktop authentication compatibility

### DIFF
--- a/deploy/config.json
+++ b/deploy/config.json
@@ -61,5 +61,17 @@
         "cookiesToFind": [
             "sails.sid"
         ]
+    },
+    "authenticationDesktop": {
+        "loginUrl": "https://www.floatplane.com/login",
+        "allowedDomains": [
+            "floatplane.com",
+            "www.floatplane.com"
+        ],
+        "userAgent": null,
+        "cookiesToFind": [
+            "sails.sid"
+        ],
+        "useMobileEmulation": false
     }
 }

--- a/deploy/config.json
+++ b/deploy/config.json
@@ -57,7 +57,7 @@
             "floatplane.com",
             "www.floatplane.com"
         ],
-        "userAgent": "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+        "userAgent": null,
         "cookiesToFind": [
             "sails.sid"
         ]


### PR DESCRIPTION
Hey @kaidelorenzo I hope you're doing well. :)

The goal of this PR is to:
1. Improve compatiblity with Grayjay Destkop authentication by:
- a) use `useMobileEmulation: false` to not make desktop's webview impersonate a mobile browser;
- b) not forcing a specific user-agent and use the webview's user-agent which has been tested to work;

2. Improve mobile authentication with older devices by not forcing an user-agent as well. Same as 1b.



