### PR TITLE
Fix long video downloads failing and looping forever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ deploy/script.ts
 
 tsconfig.tsbuildinfo
 bun.lockb
+bun.lock
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Or scan the QR code from the Grayjay app
 
 ## Missing Features
 
--   [ ] Downloading HLS streams. [MR #89](https://gitlab.futo.org/videostreaming/grayjay/-/merge_requests/89)
-    added encrypted HLS download support, but other issues upstream are blocking this from working. In the mean-time this plugin supports downloading the MP4 from creators that have enabled the ability to download videos.
 -   [ ] Playback tracking
 -   [ ] Video recommendations
 -   [ ] Channel page

--- a/deploy/config.json
+++ b/deploy/config.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://github.com/kaidelorenzo/grayjay-floatplane/releases/latest/download/config.json",
     "repositoryUrl": "https://github.com/kaidelorenzo/grayjay-floatplane",
     "scriptUrl": "./script.js",
-    "version": 6,
+    "version": 7,
     "iconUrl": "./icon.png",
     "id": "d8643244-633f-4c71-9f45-215b2387dc2c",
     "packages": [
@@ -18,7 +18,6 @@
     "allowUrls": [
         "www.floatplane.com",
         "floatplane.com",
-        "vod-download.floatplane.com",
         "cdn-vod-drm0.floatplane.com",
         "cdn-vod-drm1.floatplane.com",
         "cdn-vod-drm2.floatplane.com",

--- a/src/script.ts
+++ b/src/script.ts
@@ -737,7 +737,7 @@ function create_video_descriptor(attachments: VideoAttachment[]): VideoSourceDes
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const response: Delivery = JSON.parse(local_http.GET(url.toString(), { "User-Agent": USER_AGENT, accept: "application/json" }, true).body)
         const streamSources = response.groups.flatMap((group) => {
-            return group.variants.map((variant) => {
+            return group.variants.filter(v => v.enabled).map((variant) => {
                 const origin = group.origins[0]
                 if (origin === undefined) {
                     throw new ScriptException("unreachable")

--- a/src/script.ts
+++ b/src/script.ts
@@ -756,7 +756,6 @@ function create_video_descriptor(attachments: VideoAttachment[]): VideoSourceDes
         if (media_type === "flat") return streamSources
 
         // Also fetch flat MP4 download sources alongside HLS.
-        // Floatplane provides native download URLs via scenario=download.
         //
         // HLS downloads currently fail in Grayjay because during the download
         // prepare phase, HLS manifest sources are expanded into
@@ -768,8 +767,22 @@ function create_video_descriptor(attachments: VideoAttachment[]): VideoSourceDes
         //
         // Workaround: provide flat MP4 sources alongside HLS with no priority
         // set on either, so Grayjay's download selector can pick the flat MP4.
+        //
+        // scenario=onDemand is used instead of Floatplane's native
+        // scenario=download because download URLs are one-shot: their token
+        // expires 60 seconds after issuance, validated at request admission
+        // (HTTP 403 afterwards). An already-admitted connection streams to
+        // completion, which suits the single browser-style GET Floatplane's
+        // own site performs, but Grayjay downloads flat MP4s through
+        // thousands of separate 512 KiB ranged requests, so any download
+        // taking longer than 60 seconds fails partway through and restarts
+        // from scratch forever. The onDemand scenario serves the
+        // byte-identical MP4 from the streaming CDN with a 6 hour JWT
+        // instead. The JWT still bounds a single download attempt to
+        // 6 hours (the plugin cannot re-sign URLs mid download), but
+        // failed attempts restart with freshly issued URLs.
         const dlUrl = new URL(DELIVERY_URL)
-        dlUrl.searchParams.set("scenario", "download")
+        dlUrl.searchParams.set("scenario", "onDemand")
         dlUrl.searchParams.set("entityId", video.id)
         dlUrl.searchParams.set("outputKind", "flat")
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,12 +225,14 @@ type DeliveryVideoMetadata = {
     readonly height: number
     readonly isHdr: boolean
     readonly fps: number
-    readonly mimeType: string
+    /** present for hls outputKinds, absent for flat */
+    readonly mimeType?: string
 }
 type DeliveryAudioMetadata = {
     readonly codec: string
     readonly bitrate: MetadataBitrate
-    readonly mimeType: string
+    /** present for hls outputKinds, absent for flat */
+    readonly mimeType?: string
     readonly channelCount: number
     readonly samplerate: number
 }

--- a/tests/download-sources.test.ts
+++ b/tests/download-sources.test.ts
@@ -1,0 +1,133 @@
+//#region imports
+import { describe, test } from "node:test"
+import assert from "node:assert"
+// initializes global state
+import "@kaidelorenzo/grayjay-polyfill"
+// replaces polyfill http/bridge and injects missing grayjay classes;
+// must be imported before script.js so the plugin captures the mocks
+import {
+    LONG_LIVED_FLAT_ORIGIN,
+    MockHLSSource,
+    MockVideoUrlSource,
+    TEST_CLIENT_ID,
+    VIDEO_ATTACHMENT_ID,
+    VIDEO_DURATION,
+    created_descriptors,
+    created_hls_sources,
+    created_video_url_sources,
+    requested_urls,
+    reset_mock_state
+} from "./grayjay-mocks.js"
+// initializes source object using the mocked globals
+import "../src/script.js"
+import { StreamFormat, type Settings } from "../src/types.js"
+//#endregion
+
+const POST_URL = "https://www.floatplane.com/post/Tuxd9rAehl"
+
+function get_content_details(settings: Settings) {
+    if (source.enable === undefined || source.getContentDetails === undefined) {
+        throw new Error("Missing enable or getContentDetails method")
+    }
+    reset_mock_state()
+    source.enable({ id: "test-config" }, settings, null)
+    return source.getContentDetails(POST_URL)
+}
+
+// Regression test for long-video downloads failing and retrying forever.
+//
+// Floatplane's scenario=download delivery URLs carry tokens that expire
+// 60 seconds after issuance, enforced per request. Grayjay downloads flat
+// MP4s through thousands of separate ranged requests, so any video whose
+// download takes longer than 60 seconds fails with HTTP 403 partway
+// through and restarts from scratch indefinitely. scenario=onDemand
+// serves the byte-identical MP4 with a 6 hour JWT, so download sources
+// must only ever come from scenario=onDemand.
+await Promise.allSettled([describe("download sources", { skip: false }, async () => {
+    await Promise.allSettled([
+        test("long video download sources use long-lived onDemand urls", { skip: false }, () => {
+            get_content_details({ stream_format: StreamFormat.HLS, log_toasts: false })
+
+            // the 60 second token scenario must never be requested, and the
+            // download request must ask for flat MP4s, not HLS playlists
+            const deliveries = requested_urls
+                .map(url => new URL(url))
+                .filter(url => url.pathname === "/api/v3/delivery/info")
+            assert.deepStrictEqual(
+                deliveries.map(url => ({
+                    scenario: url.searchParams.get("scenario"),
+                    outputKind: url.searchParams.get("outputKind")
+                })),
+                [
+                    { scenario: "onDemand", outputKind: "hls.fmp4" },
+                    { scenario: "onDemand", outputKind: "flat" }
+                ],
+                "download URLs from scenario=download expire after 60 seconds; long videos cannot finish downloading before expiry"
+            )
+
+            // flat MP4 download sources must be the long-lived onDemand
+            // variants, with disabled variants excluded
+            assert.strictEqual(created_video_url_sources.length, 2, "expected exactly the two enabled flat variants")
+            for (const def of created_video_url_sources) {
+                assert.ok(
+                    def.url.startsWith(`${LONG_LIVED_FLAT_ORIGIN}/Videos/${VIDEO_ATTACHMENT_ID}/`),
+                    `flat source url must come from origins[0] of the onDemand delivery response, got: ${def.url}`
+                )
+                assert.match(def.url, /\.mp4\?token=LONG_LIVED_JWT/, "flat source must be a direct MP4 with the long-lived token")
+                assert.strictEqual(def.container, "video/mp4")
+                assert.strictEqual(def.duration, VIDEO_DURATION)
+                assert.strictEqual(def.requestModifier?.options?.applyAuthClient, TEST_CLIENT_ID)
+            }
+
+            // streaming sources must keep their auth modifier: Grayjay's HLS
+            // download path already loses it (see create_video_descriptor),
+            // losing it on playback too would break every stream
+            assert.strictEqual(created_hls_sources.length, 2)
+            for (const def of created_hls_sources) {
+                assert.match(def.url, /playlist_fmp4\.m3u8\?token=LONG_LIVED_JWT/)
+                assert.strictEqual(def.duration, VIDEO_DURATION)
+                assert.strictEqual(def.requestModifier?.options?.applyAuthClient, TEST_CLIENT_ID)
+            }
+
+            // flat sources must precede HLS sources so Grayjay's download
+            // selector picks the flat MP4 (HLS downloads fail, see
+            // create_video_descriptor)
+            assert.strictEqual(created_descriptors.length, 1)
+            const descriptor_sources = created_descriptors[0]
+            assert.ok(descriptor_sources !== undefined)
+            assert.deepStrictEqual(
+                descriptor_sources.map(source_entry => {
+                    if (source_entry instanceof MockVideoUrlSource) return "flat"
+                    if (source_entry instanceof MockHLSSource) return "hls"
+                    return "unknown"
+                }),
+                ["flat", "flat", "hls", "hls"]
+            )
+        }),
+        test("flat MP4 setting excludes disabled variants from streaming sources", { skip: false }, () => {
+            get_content_details({ stream_format: StreamFormat.FlatMP4, log_toasts: false })
+
+            // single delivery request: streaming sources double as downloads
+            const deliveries = requested_urls
+                .map(url => new URL(url))
+                .filter(url => url.pathname === "/api/v3/delivery/info")
+            assert.deepStrictEqual(
+                deliveries.map(url => ({
+                    scenario: url.searchParams.get("scenario"),
+                    outputKind: url.searchParams.get("outputKind")
+                })),
+                [{ scenario: "onDemand", outputKind: "flat" }]
+            )
+
+            // the disabled 2160p variant must not become a selectable source
+            assert.strictEqual(created_video_url_sources.length, 2, "expected exactly the two enabled flat variants")
+            for (const def of created_video_url_sources) {
+                assert.doesNotMatch(def.url, /2160/, "disabled variants must be excluded from streaming sources")
+                assert.match(def.url, /\.mp4\?token=LONG_LIVED_JWT/)
+            }
+            assert.strictEqual(created_descriptors.length, 1)
+            assert.strictEqual(created_descriptors[0]?.length, 2)
+            assert.strictEqual(created_hls_sources.length, 0)
+        })
+    ])
+})])

--- a/tests/grayjay-mocks.ts
+++ b/tests/grayjay-mocks.ts
@@ -1,0 +1,223 @@
+//#region grayjay mock environment
+// Replaces the polyfill's http/bridge globals and injects the grayjay
+// classes the polyfill does not implement. Import this module AFTER
+// @kaidelorenzo/grayjay-polyfill and BEFORE src/script.js so the plugin
+// captures the mocked globals at load time.
+import type { Delivery } from "../src/types.js"
+
+// Fail fast on import order violations: a misordered import would make
+// the polyfill's sync-fetch http issue live requests to floatplane.com.
+if (!("source" in globalThis)) {
+    throw new Error("grayjay-mocks must be imported after @kaidelorenzo/grayjay-polyfill")
+}
+if (source.enable !== undefined) {
+    throw new Error("grayjay-mocks must be imported before src/script.js")
+}
+
+export const TEST_CLIENT_ID = "test-client-id"
+export const POST_ID = "Tuxd9rAehl"
+export const VIDEO_ATTACHMENT_ID = "VoAGr7LOVl"
+export const VIDEO_DURATION = 14128
+
+/** origin used by scenario=onDemand deliveries (6 hour JWT tokens) */
+export const LONG_LIVED_FLAT_ORIGIN = "https://cdn-vod-drm2.floatplane.com"
+/** origin used by scenario=download deliveries (60 second tokens) */
+export const SHORT_LIVED_DOWNLOAD_ORIGIN = "https://vod-download.floatplane.com"
+
+export const requested_urls: string[] = []
+export const created_video_url_sources: IVideoUrlSourceDef[] = []
+export const created_hls_sources: IHLSSourceDef[] = []
+export const created_descriptors: IVideoSource[][] = []
+
+/** empties every spy array; call at the start of each test */
+export function reset_mock_state() {
+    requested_urls.length = 0
+    created_video_url_sources.length = 0
+    created_hls_sources.length = 0
+    created_descriptors.length = 0
+}
+
+//#region fixtures
+// Trimmed copies of real API responses for post Tuxd9rAehl
+// (3h55m WAN Show VOD, 2.29 GB at 1080p).
+const post_fixture = {
+    id: POST_ID,
+    title: "Livestream VOD - WAN Show July 10, 2026",
+    text: "<p>fixture</p>",
+    thumbnail: null,
+    releaseDate: "2026-07-11T04:00:00.000Z",
+    likes: 100,
+    dislikes: 2,
+    metadata: {
+        hasVideo: true,
+        hasAudio: false,
+        hasPicture: false,
+        hasGallery: false,
+        videoDuration: VIDEO_DURATION
+    },
+    videoAttachments: [{ id: VIDEO_ATTACHMENT_ID, duration: VIDEO_DURATION }],
+    creator: { urlname: "linustechtips" },
+    channel: {
+        creator: "59f94c0bdd241b70349eb72b",
+        id: "6413534d88c13c181c3e2809",
+        title: "The WAN Show",
+        urlname: "wan",
+        icon: null
+    }
+}
+
+function delivery_variant(label: string, url: string, enabled: boolean, mime_type: string) {
+    return {
+        name: label,
+        label,
+        url,
+        mimeType: mime_type,
+        order: 111745216,
+        hidden: false,
+        enabled,
+        meta: {
+            video: {
+                codec: "avc1.640028",
+                codecSimple: "avc1",
+                bitrate: { average: 1155310 },
+                width: 1920,
+                height: 1080,
+                isHdr: false,
+                fps: 30
+                // meta.video.mimeType deliberately omitted: real flat
+                // delivery responses do not carry it (hls responses do)
+            }
+        }
+    }
+}
+
+const on_demand_hls_delivery_fixture = {
+    groups: [{
+        origins: [{ url: LONG_LIVED_FLAT_ORIGIN }],
+        variants: [
+            delivery_variant("720p", `/Videos/${VIDEO_ATTACHMENT_ID}/720.mp4/playlist_fmp4.m3u8?token=LONG_LIVED_JWT_720`, true, "application/x-mpegURL"),
+            delivery_variant("1080p", `/Videos/${VIDEO_ATTACHMENT_ID}/1080.mp4/playlist_fmp4.m3u8?token=LONG_LIVED_JWT_1080`, true, "application/x-mpegURL")
+        ]
+    }]
+} satisfies Delivery
+
+// origins[1] is a decoy: the plugin must build sources from origins[0]
+const on_demand_flat_delivery_fixture = {
+    groups: [{
+        origins: [{ url: LONG_LIVED_FLAT_ORIGIN }, { url: "https://cdn-vod-drm5.floatplane.com" }],
+        variants: [
+            delivery_variant("360p", `/Videos/${VIDEO_ATTACHMENT_ID}/360.mp4?token=LONG_LIVED_JWT_360`, true, "video/mp4"),
+            delivery_variant("1080p", `/Videos/${VIDEO_ATTACHMENT_ID}/1080.mp4?token=LONG_LIVED_JWT_1080`, true, "video/mp4"),
+            delivery_variant("2160p", `/Videos/${VIDEO_ATTACHMENT_ID}/2160.mp4?token=LONG_LIVED_JWT_2160`, false, "video/mp4")
+        ]
+    }]
+} satisfies Delivery
+
+// Served if the implementation regresses to scenario=download.
+// These tokens expire 60 seconds after issuance, so Grayjay's chunked
+// downloader can never finish a long video with them.
+const download_delivery_fixture = {
+    groups: [{
+        origins: [{ url: SHORT_LIVED_DOWNLOAD_ORIGIN }],
+        variants: [
+            delivery_variant("360p", `/${VIDEO_ATTACHMENT_ID}/360.mp4?token=SHORT_LIVED_60S_360&expires=1784064169`, true, "video/mp4"),
+            delivery_variant("1080p", `/${VIDEO_ATTACHMENT_ID}/1080.mp4?token=SHORT_LIVED_60S_1080&expires=1784064169`, true, "video/mp4")
+        ]
+    }]
+} satisfies Delivery
+//#endregion
+
+//#region fake http
+function respond(url: string, body: unknown): BridgeHttpResponse<string> {
+    return { body: JSON.stringify(body), code: 200, headers: {}, url, isOk: true }
+}
+
+function fake_http_get(url: string, _headers: HTTPHeaders, _use_auth_client: boolean): BridgeHttpResponse<string> {
+    requested_urls.push(url)
+    const parsed = new URL(url)
+    if (parsed.pathname === "/api/v3/content/post") {
+        return respond(url, post_fixture)
+    }
+    if (parsed.pathname === "/api/v3/delivery/info") {
+        const scenario = parsed.searchParams.get("scenario")
+        const output_kind = parsed.searchParams.get("outputKind")
+        if (scenario === "download") {
+            return respond(url, download_delivery_fixture)
+        }
+        if (scenario === "onDemand" && output_kind === "flat") {
+            return respond(url, on_demand_flat_delivery_fixture)
+        }
+        if (scenario === "onDemand" && (output_kind === "hls.fmp4" || output_kind === "hls.mpegts")) {
+            return respond(url, on_demand_hls_delivery_fixture)
+        }
+    }
+    // any unrecognized scenario/outputKind combination lands here
+    throw new Error(`unexpected request in test: ${url}`)
+}
+
+const fake_http = {
+    GET: fake_http_get,
+    getDefaultClient: (_with_auth: boolean) => ({ clientId: TEST_CLIENT_ID })
+}
+// @ts-expect-error inject fake http into global scope for script.js
+globalThis.http = fake_http
+//#endregion
+
+//#region fake bridge and classes
+const fake_bridge: typeof bridge = {
+    isLoggedIn: () => true,
+    toast: (message: string) => { console.log(`Toast: ${message}`) },
+    throwTest: (message: string) => { console.log(`Throw test: ${message}`) }
+}
+// @ts-expect-error inject fake bridge into global scope for script.js
+globalThis.bridge = fake_bridge
+
+export class MockVideoUrlSource {
+    constructor(readonly def: IVideoUrlSourceDef) {
+        created_video_url_sources.push(def)
+    }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.VideoUrlSource = MockVideoUrlSource
+
+export class MockHLSSource {
+    constructor(readonly def: IHLSSourceDef) {
+        created_hls_sources.push(def)
+    }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.HLSSource = MockHLSSource
+
+export class MockVideoSourceDescriptor {
+    constructor(readonly videoSources: IVideoSource[]) {
+        created_descriptors.push(videoSources)
+    }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.VideoSourceDescriptor = MockVideoSourceDescriptor
+
+export class MockPlatformVideoDetails {
+    constructor(readonly def: IPlatformVideoDetailsDef) { }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.PlatformVideoDetails = MockPlatformVideoDetails
+
+export class MockRatingLikesDislikes {
+    constructor(readonly likes: number, readonly dislikes: number) { }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.RatingLikesDislikes = MockRatingLikesDislikes
+
+export class MockScriptException extends Error {
+    constructor(type: string, msg?: string) {
+        super(msg ?? type)
+    }
+}
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.ScriptException = MockScriptException
+
+export class MockLoginRequiredException extends MockScriptException { }
+// @ts-expect-error inject mock class into global scope for script.js
+globalThis.LoginRequiredException = MockLoginRequiredException
+//#endregion
+//#endregion


### PR DESCRIPTION
Downloading longer (multi-hour long) videos would fail due to the TTL of the download link expiring. This was because we were using `scenario=download` and Grayjay's download behavior is to use ranged requests instead of a single GET request (which is what Floatplane wants you to do).

The solution was to use `scenario=onDemand&outputKind=flat` instead, which, and I tested this, results in the exact same video file hash-wise.

Also includes some misc fixes and regression tests.

I used Claude Opus 4.8 to implement and test these changes, but I have read it all myself.